### PR TITLE
fix #13218: avoid some irrelevant warnings for nim doc,rst2html,--app…

### DIFF
--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -225,6 +225,12 @@ proc mainCommand*(graph: ModuleGraph) =
       loadConfigs(DocConfig, cache, conf)
       commandDoc(cache, conf)
   of "doc2", "doc":
+    conf.setNoteDefaults(warnLockLevel, false) # issue #13218
+    conf.setNoteDefaults(warnRedefinitionOfLabel, false) # issue #13218
+      # because currently generates lots of false positives due to conflation
+      # of labels links in doc comments, eg for random.rand:
+      #  ## * `rand proc<#rand,Rand,Natural>`_ that returns an integer
+      #  ## * `rand proc<#rand,Rand,range[]>`_ that returns a float
     when defined(leanCompiler):
       quit "compiler wasn't built with documentation generator"
     else:
@@ -233,6 +239,7 @@ proc mainCommand*(graph: ModuleGraph) =
       defineSymbol(conf.symbols, "nimdoc")
       commandDoc2(graph, false)
   of "rst2html":
+    conf.setNoteDefaults(warnRedefinitionOfLabel, false) # similar to issue #13218
     when defined(leanCompiler):
       quit "compiler wasn't built with documentation generator"
     else:

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -289,7 +289,15 @@ type
                                 severity: Severity) {.closure, gcsafe.}
     cppCustomNamespace*: string
 
+proc setNoteDefaults*(conf: ConfigRef, note: TNoteKind, enabled = true) =
+  template fun(op) =
+    conf.notes.op note
+    conf.mainPackageNotes.op note
+    conf.foreignPackageNotes.op note
+  if enabled: fun(incl) else: fun(excl)
+
 proc setNote*(conf: ConfigRef, note: TNoteKind, enabled = true) =
+  # see also `prepareConfigNotes` which sets notes
   if note notin conf.cmdlineNotes:
     if enabled: incl(conf.notes, note) else: excl(conf.notes, note)
 

--- a/doc/docgen_sample.nim
+++ b/doc/docgen_sample.nim
@@ -4,9 +4,9 @@ import strutils
 
 proc helloWorld*(times: int) =
   ## Takes an integer and outputs
-  ## as many "hello world!"s
+  ## as many indented "hello world!"s
 
   for i in 0 .. times-1:
-    echo "hello world!"
+    echo "hello world!".indent(2) # using indent to avoid `UnusedImport`
 
 helloWorld(5)

--- a/lib/impure/rdstdin.nim
+++ b/lib/impure/rdstdin.nim
@@ -43,7 +43,7 @@ elif defined(genode):
     stdin.readLine(line)
 
 else:
-  import linenoise, termios
+  import linenoise
 
   proc readLineFromStdin*(prompt: string): TaintedString {.
                           tags: [ReadIOEffect, WriteIOEffect].} =

--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -168,7 +168,7 @@
 
 include "system/inclrtl"
 
-import os, tables, strutils, times, heapqueue, lists, options, asyncstreams
+import os, tables, strutils, times, heapqueue, options, asyncstreams
 import options, math, std/monotimes
 import asyncfutures except callSoon
 

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -30,7 +30,7 @@
 ##
 ##    waitFor server.serve(Port(8080), cb)
 
-import tables, asyncnet, asyncdispatch, parseutils, uri, strutils
+import asyncnet, asyncdispatch, parseutils, uri, strutils
 import httpcore
 
 export httpcore except parseHeader

--- a/lib/pure/encodings.nim
+++ b/lib/pure/encodings.nim
@@ -10,7 +10,7 @@
 ## Converts between different character encodings. On UNIX, this uses
 ## the `iconv`:idx: library, on Windows the Windows API.
 
-import os, parseutils, strutils
+import os
 
 when not defined(windows):
   type
@@ -28,6 +28,7 @@ type
                                         ## for encoding errors
 
 when defined(windows):
+  import parseutils, strutils
   proc eqEncodingNames(a, b: string): bool =
     var i = 0
     var j = 0

--- a/lib/pure/lenientops.nim
+++ b/lib/pure/lenientops.nim
@@ -24,8 +24,6 @@
 ## either casting to float or rounding to int might be preferred, and users
 ## should make an explicit choice.
 
-import typetraits
-
 proc `+`*[I: SomeInteger, F: SomeFloat](i: I, f: F): F {.noSideEffect, inline.} =
   F(i) + f
 proc `+`*[I: SomeInteger, F: SomeFloat](f: F, i: I): F {.noSideEffect, inline.} =

--- a/lib/pure/selectors.nim
+++ b/lib/pure/selectors.nim
@@ -27,7 +27,7 @@
 ##
 ## TODO: ``/dev/poll``, ``event ports`` and filesystem events.
 
-import os, strutils, nativesockets
+import os, nativesockets
 
 const hasThreadSupport = compileOption("threads") and defined(threadsafe)
 
@@ -230,6 +230,7 @@ when defined(nimdoc):
     ## For *poll* and *select* selectors ``-1`` is returned.
 
 else:
+  import strutils
   when hasThreadSupport:
     import locks
 

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -744,8 +744,6 @@ when isMainModule:
   check &"{high(int64)}", "9223372036854775807"
   check &"{low(int64)}", "-9223372036854775808"
 
-  import json
-
   doAssert fmt"{'a'} {'b'}" == "a b"
 
   echo("All tests ok")

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -149,8 +149,10 @@ lib/posix/linux.nim
 lib/posix/termios.nim
 lib/js/jscore.nim
 """.splitWhitespace()
-
+  
+  # some of these are include files so shouldn't be docgen'd
   ignoredModules = """
+lib/prelude.nim
 lib/pure/future.nim
 lib/impure/osinfo_posix.nim
 lib/impure/osinfo_win.nim


### PR DESCRIPTION
…:lib, + other fixes (#13550)

* fix #13218: avoid some irrelevant warnings for nim doc,rst2html
* suppress warnRedefinitionOfLabel for nim doc
* lots of fixes for UnusedImport warnings