### PR TITLE
IC exposes typedesc implementation shenanigans (#17759)

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -980,7 +980,7 @@ proc `@`* [IDX, T](a: sink array[IDX, T]): seq[T] {.magic: "ArrToSeq", noSideEff
   ##   echo @a # => @[1, 3, 5]
   ##   echo @b # => @['f', 'o', 'o']
 
-proc default*(T: typedesc): T {.magic: "Default", noSideEffect.} =
+proc default*[T](_: typedesc[T]): T {.magic: "Default", noSideEffect.} =
   ## returns the default value of the type `T`.
   runnableExamples:
     assert (int, float).default == (0, 0.0)

--- a/tests/ic/tstdlib_import_changed.nim
+++ b/tests/ic/tstdlib_import_changed.nim
@@ -1,0 +1,15 @@
+discard """
+  output: '''yes'''
+"""
+
+echo "yes"
+
+#!EDIT!#
+
+discard """
+  output: '''yes2'''
+"""
+
+import std / [monotimes]
+#discard getMonoTime()
+echo "yes2"


### PR DESCRIPTION
* IC exposes typedesc implementation shenanigans; so I change system.default's definition to what it should have been to begin with
* Update lib/system.nim

Co-authored-by: Timothee Cour <timothee.cour2@gmail.com>