### PR TITLE
cross compilation targetting windows now supports `nim r`: `nim r -d:…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -482,6 +482,9 @@
   nim r main # uses cached binary
   nim r main arg1 arg2 # ditto (runtime arguments are irrelevant)
 
+- `nim r` now supports cross compilation from unix to windows when specifying `-d:mingw` by using wine,
+  e.g.: `nim r --eval:'import os; echo "a" / "b"'` prints `a\b`
+
 - The style checking of the compiler now supports a `--styleCheck:usages` switch. This switch
   enforces that every symbol is written as it was declared, not enforcing
   the official Nim style guide. To be enabled, this has to be combined either

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -317,6 +317,8 @@ To cross-compile for Windows from Linux or macOS using the MinGW-w64 toolchain:
 .. code:: cmd
 
   nim c -d:mingw myproject.nim
+  # `nim r` also works, running the binary via `wine` or `wine64`:
+  nim r -d:mingw --eval:'import os; echo "a" / "b"'
 
 Use `--cpu:i386`:option: or `--cpu:amd64`:option: to switch the CPU architecture.
 


### PR DESCRIPTION
…mingw main` (#18682)

* cross compilation targetting windows now supports `nim r`: `nim r -d:mingw main`

* quoteShell

* address comment: remove `conf.getConfigVar("nimrun.exe")`